### PR TITLE
Use DINOv3's post-layernorm output in the vision encoder

### DIFF
--- a/turbovla/models/vision_encoder.py
+++ b/turbovla/models/vision_encoder.py
@@ -106,8 +106,12 @@ class DINOv3VisionEncoder(nn.Module):
         grad_context = torch.no_grad() if self.config.frozen else nullcontext()
         with grad_context:
             with autocast_context:
-                outputs = self.backbone(pixel_values=pixel_values, output_hidden_states=True)
-        tokens = outputs.hidden_states[-1] if outputs.hidden_states is not None else outputs.last_hidden_state
+                outputs = self.backbone(pixel_values=pixel_values)
+        # Use the post-layernorm output. hidden_states[-1] is the last block's
+        # output *before* DINOv3's final layernorm and is ~76x larger in
+        # magnitude (mean |x| 25.9 vs 0.34), which puts the vision tokens far
+        # outside the distribution the released checkpoints were trained on.
+        tokens = outputs.last_hidden_state
         if tokens.shape[1] == expected_patches + self.prefix_tokens:
             return tokens[:, self.prefix_tokens :, :]
         if tokens.shape[1] == expected_patches:


### PR DESCRIPTION
`DINOv3VisionEncoder._encode_images` reads `outputs.hidden_states[-1]`, which is the last transformer block's output before DINOv3's final layernorm. It should read `outputs.last_hidden_state`, the same tensor after that layernorm.

The two differ by roughly 76x in magnitude (mean `|x|` of 25.89 against 0.34), so the policy sees vision tokens well outside the range the released checkpoints were trained on.

```python
outputs = self.backbone(pixel_values=pixel_values, output_hidden_states=True)
tokens = outputs.hidden_states[-1] if outputs.hidden_states is not None else outputs.last_hidden_state
```

The fallback branch already names the right tensor, but nothing can reach it. The call passes `output_hidden_states=True`, so `hidden_states` is never `None`.

## Impact

I ran LIBERO with the released checkpoints, the evaluation command from the README, and the shipped `libero_all4_stats.json`. This line is the only difference between the two columns below. Every cell is a full 500-episode run (10 tasks, 50 trials each, seed 7, `chunk_size 12`, `num_open_loop_steps 12`, bf16), so 2,000 episodes per column.

| Suite | Reported | Before | After |
| --- | ---: | ---: | ---: |
| Spatial | 99.2 | 80.8 | 98.6 |
| Object | 99.8 | 69.4 | 100.0 |
| Goal | 97.4 | 57.0 | 96.4 |
| Long | 94.2 | 33.6 | 93.4 |
| Average | 97.7 | 60.2 | 97.1 |

`libero_goal` task 0, "open the middle drawer of the cabinet", went from 0/50 to 50/50. I instrumented the simulator on that one because the failure was so consistent, and the drawer joint turned out never to move at all. The arm reached the handle and stalled there.

## Notes

This is shared model code, so it affects training as well as evaluation. `experiments/libero/train.py` reaches the same encoder through `build_turbovla`. Fixing inference alone recovers the reported numbers, which suggests the released checkpoints were trained on post-layernorm features.

`vision_encoder.py` was added in 2d42436 on Aug 1, a day after the checkpoints went up, so the weights themselves look unaffected.

The remaining 0.6 gap is more likely environmental than another bug. I measured on an RTX 5090 (sm_120), which needs torch 2.11+cu128 rather than the pinned 2.3.1+cu121, and EGL rather than the default OSMesa renderer. I confirmed EGL and GLFW render pixel-identical output, but I did not isolate the torch version, so treat that attribution as untested.

Two smaller things I noticed and left alone here: `--dinov3_output_hidden_states` is stored on the policy and printed at startup but never reaches the model, and `--precision bf16` hard-casts the DINOv3 weights while the checkpoints' embedded `model_config` records `bf16_autocast`. I tested the precision one and it made no difference.